### PR TITLE
Make batch.id robust to warning messages from sbatch

### DIFF
--- a/R/clusterFunctionsSlurm.R
+++ b/R/clusterFunctionsSlurm.R
@@ -66,7 +66,8 @@ makeClusterFunctionsSlurm = function(template = "slurm", array.jobs = TRUE, node
       return(cfHandleUnknownSubmitError("sbatch", res$exit.code, res$output))
     }
 
-    id = stri_split_fixed(output[1L], " ")[[1L]][4L]
+    submitted = grep("^Submitted batch job", stri_split_fixed(output, '\n')[[1L]], value = TRUE)
+    id = stri_split_fixed(submitted, " ")[[1L]][4L]
     if (jc$array.jobs) {
       if (!array.jobs)
         stop("Array jobs not supported by cluster function")


### PR DESCRIPTION
I ran into a crazy bug today: `getJobStatus` gave me `batch.id = "that"`. It turns out that when I requested a large amount of memory, `sbatch` returned this um, helpful message:
```
sbatch: INFO: Note that 128 GB per node will require a node with more than 128 GB memory 
because of overhead. Check https://docs.unity.rc.umass.edu/nodes for an appropriate limit.
Submitted batch job 38139957
```
`clusterFunctionsSlurm` was pulling the 4th word of the first line, which should have been the Slurm jobid, but instead was "that". It wanted, of course, the last line.

This really isn't a bug in `batchtools`, as the sysops inserted an informational message in a crazy place. But I suspect if the smart, on the ball people at the UMass Unity cluster are doing this, others probably are too. It'd be nice for `batchtools` to be robust to such shenanigans. Alternatively, I suppose it could throw an error if `batch.id` is non-numeric and print the message from `sbatch`.

My suggested change looks for a line beginning with "Submitted batch job" and pulls the 4th word as the `batch.id`.

I've tested this change against the following:
```
output <- 'Submitted batch job 12345678'
output <- 'This is a crazy informational message\nSubmitted batch job 98765432'
output <- 'This is crazy\nand uncalled for\nSubmitted batch job 5555555\nand even more stuff'
```
as well as against real-life `submitJobs` calls, both with and without the informational message.
